### PR TITLE
Update GetSDSHealth to use bucketName parameter

### DIFF
--- a/api-distributed-storage-health.go
+++ b/api-distributed-storage-health.go
@@ -15,7 +15,7 @@ type StorageStatus struct {
 }
 
 func (c *Client) GetSDSHealth(ctx context.Context, bucketName, objectName string, opts GetObjectOptions) ([]StorageStatus, error) {
-	resp, err := c.executeMethod(ctx, http.MethodGet, requestMetadata{contentSHA256Hex: emptySHA256Hex, health: true})
+	resp, err := c.executeMethod(ctx, http.MethodGet, requestMetadata{bucketName: bucketName, contentSHA256Hex: emptySHA256Hex, health: true})
 	defer closeResponse(resp)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- Update GetSDSHealth to use bucketName parameter

When the executeMethod in GetSDSHealth uses the buucketName it sends a request with the bucketName in it